### PR TITLE
Fixes: 8761c2820713 ("timestamp truncation on call of mcp25xxfd_can_queue_frame()")

### DIFF
--- a/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can.h
+++ b/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can.h
@@ -23,7 +23,7 @@ int mcp25xxfd_can_targetmode(struct mcp25xxfd_can_priv *cpriv)
 
 static inline
 void mcp25xxfd_can_queue_frame(struct mcp25xxfd_can_priv *cpriv,
-			       s32 fifo, u16 ts, bool is_rx)
+			       s32 fifo, u32 ts, bool is_rx)
 {
 	int idx = cpriv->fifos.submit_queue_count;
 


### PR DESCRIPTION
Changed datatype of parameter ts in mcp25xxfd_can_queue_frame in order to avoid
truncation of the timestamp value.