### PR TITLE
Fixes: d27792a603fe ("clear TX FIFOs on interface shutdown to avoid send errors/exceptions")

### DIFF
--- a/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can.c
+++ b/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can.c
@@ -579,6 +579,9 @@ static int mcp25xxfd_can_stop(struct net_device *net)
 	/* shutdown the can controller */
 	mcp25xxfd_can_shutdown(cpriv);
 
+	/* reset can controller */
+	mcp25xxfd_cmd_reset(spi);
+
 	/* stop the clock */
 	mcp25xxfd_clock_stop(cpriv->priv, MCP25XXFD_CLK_USER_CAN);
 

--- a/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can_fifo.c
+++ b/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can_fifo.c
@@ -272,6 +272,15 @@ static int mcp25xxfd_can_fifo_clear(struct mcp25xxfd_can_priv *cpriv)
 	memset(&cpriv->fifos.tx, 0, sizeof(cpriv->fifos.tx));
 	memset(&cpriv->fifos.rx, 0, sizeof(cpriv->fifos.rx));
 
+	/* fix to avoid problems when stopping/starting interface due to
+	 * FIFO confusion - maybe not cleared structures
+	 */
+	memset(&cpriv->fifos.tef, 0, sizeof(cpriv->fifos.tef));
+	memset(&cpriv->fifos.submit_queue, 0,
+	       sizeof(cpriv->fifos.submit_queue));
+
+	cpriv->fifos.submit_queue_count = 0;
+
 	/* clear FIFO config */
 	ret = mcp25xxfd_can_fifo_clear_regs(cpriv, MCP25XXFD_CAN_FIFOCON(1),
 					    MCP25XXFD_CAN_FIFOCON(32));


### PR DESCRIPTION
Added a reset on interface stop in mcp25xxfd_can_stop() and cleared TEF and submit
queue in order to stop all pending send operations. Without the fix, we sometimes
observed exceptions because no TX FIFO was left to send on as it was occupied and
never freed, as well as a bulk send of data after reactivating data from previously
configured TEFs.